### PR TITLE
 Fix duplicate port error in FlexCounter bulk stats collection

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
+      pool: sonicso1ES-amd64
       sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       artifact_name: sonic-sairedis-${{ parameters.debian_version }}
@@ -66,6 +67,7 @@ stages:
   - template: .azure-pipelines/build-template.yml
     parameters:
       arch: amd64
+      pool: sonicso1ES-amd64
       sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       artifact_name: sonic-sairedis-asan-${{ parameters.debian_version }}

--- a/configure.ac
+++ b/configure.ac
@@ -284,8 +284,7 @@ AM_COND_IF([SAIVS],
     AM_COND_IF([SYNCD], [
     SAVED_FLAGS="$CXXFLAGS"
     CXXFLAGS="-Xlinker --no-as-needed -lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
-    AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_tam_telemetry_get_data)
-    AH_TEMPLATE([HAVE_SAI_QUERY_STATS_ST_CAPABILITY], [Force it disabled for SAIs without implementation - REMOVE WHEN NOT NEEDED])
+    AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats sai_query_stats_st_capability sai_tam_telemetry_get_data)
     CXXFLAGS="$SAVED_FLAGS"
     ])
 ])

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -18,11 +18,6 @@
 
 #define CHECK_STATUS_SUCCESS(s) { if ((s) != SAI_STATUS_SUCCESS) return (s); }
 
-#define CHECK_STATUS_SUCCESS_MODE(s,m)                                                          \
-{                                                                                               \
-    if ((s) != SAI_STATUS_SUCCESS && m != SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR) return (s);      \
-}                                                                                               \
-
 #define VALIDATION_LIST(md,vlist)                                               \
 {                                                                               \
     auto _status = meta_genetic_validation_list(md,vlist.count,vlist.list);     \
@@ -628,14 +623,14 @@ sai_status_t Meta::bulkCreate(                                                  
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], true);                                                 \
-        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
+        CHECK_STATUS_SUCCESS(status);                                                                                   \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
              };                                                                                                         \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_create(meta_key, ot[idx].switch_id, attr_count[idx], attr_list[idx]);          \
-        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
+        CHECK_STATUS_SUCCESS(status);                                                                                   \
     }                                                                                                                   \
     auto status = m_implementation->bulkCreate(object_count, ot, attr_count, attr_list, mode, object_statuses);         \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
@@ -672,14 +667,14 @@ sai_status_t Meta::bulkRemove(                                                  
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], false);                                                \
-        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
+        CHECK_STATUS_SUCCESS(status);                                                                                   \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
             };                                                                                                          \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_remove(meta_key);                                                              \
-        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
+        CHECK_STATUS_SUCCESS(status);                                                                                   \
     }                                                                                                                   \
     auto status = m_implementation->bulkRemove(object_count, ot, mode, object_statuses);                                \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
@@ -718,14 +713,14 @@ sai_status_t Meta::bulkSet(                                                     
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
     {                                                                                                                   \
         sai_status_t status = meta_sai_validate_ ##ot (&ot[idx], false);                                                \
-        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
+        CHECK_STATUS_SUCCESS(status);                                                                                   \
         sai_object_meta_key_t meta_key = {                                                                              \
             .objecttype = (sai_object_type_t)SAI_OBJECT_TYPE_ ## OT,                                                    \
             .objectkey = { .key = { .ot = ot[idx] } }                                                                   \
              };                                                                                                         \
         vmk.push_back(meta_key);                                                                                        \
         status = meta_generic_validation_set(meta_key, &attr_list[idx]);                                                \
-        CHECK_STATUS_SUCCESS_MODE(status, mode);                                                                        \
+        CHECK_STATUS_SUCCESS(status);                                                                                   \
     }                                                                                                                   \
     auto status = m_implementation->bulkSet(object_count, ot, attr_list, mode, object_statuses);                        \
     for (uint32_t idx = 0; idx < object_count; idx++)                                                                   \
@@ -1211,7 +1206,7 @@ sai_status_t Meta::bulkRemove(
     {
         sai_status_t status = meta_sai_validate_oid(object_type, &object_id[idx], SAI_NULL_OBJECT_ID, false);
 
-        CHECK_STATUS_SUCCESS_MODE(status, mode);
+        CHECK_STATUS_SUCCESS(status);
 
         sai_object_meta_key_t meta_key = { .objecttype = object_type, .objectkey = { .key = { .object_id  = object_id[idx] } } };
 
@@ -1219,7 +1214,7 @@ sai_status_t Meta::bulkRemove(
 
         status = meta_generic_validation_remove(meta_key);
 
-        CHECK_STATUS_SUCCESS_MODE(status, mode);
+        CHECK_STATUS_SUCCESS(status);
     }
 
     auto status = m_implementation->bulkRemove(object_type, object_count, object_id, mode, object_statuses);
@@ -1273,7 +1268,7 @@ sai_status_t Meta::bulkSet(
     {
         sai_status_t status = meta_sai_validate_oid(object_type, &object_id[idx], SAI_NULL_OBJECT_ID, false);
 
-        CHECK_STATUS_SUCCESS_MODE(status, mode);
+        CHECK_STATUS_SUCCESS(status);
 
         sai_object_meta_key_t meta_key = { .objecttype = object_type, .objectkey = { .key = { .object_id  = object_id[idx] } } };
 
@@ -1281,7 +1276,7 @@ sai_status_t Meta::bulkSet(
 
         status = meta_generic_validation_set(meta_key, &attr_list[idx]);
 
-        CHECK_STATUS_SUCCESS_MODE(status, mode);
+        CHECK_STATUS_SUCCESS(status);
     }
 
     auto status = m_implementation->bulkSet(object_type, object_count, object_id, attr_list, mode, object_statuses);
@@ -1333,7 +1328,7 @@ sai_status_t Meta::bulkGet(
     {
         sai_status_t status = meta_sai_validate_oid(object_type, &object_id[idx], SAI_NULL_OBJECT_ID, false);
 
-        CHECK_STATUS_SUCCESS_MODE(status, mode);
+        CHECK_STATUS_SUCCESS(status);
 
         sai_object_meta_key_t meta_key = { .objecttype = object_type, .objectkey = { .key = { .object_id  = object_id[idx] } } };
 
@@ -1341,7 +1336,10 @@ sai_status_t Meta::bulkGet(
 
         status = meta_generic_validation_get(meta_key, attr_count[idx], attr_list[idx]);
 
-        CHECK_STATUS_SUCCESS_MODE(status, mode);
+        // FIXME: This macro returns on failure.
+        // When mode is SAI_BULK_OP_ERROR_MODE_IGNORE_ERROR we should continue instead of return.
+        // This issue exists for all bulk operations.
+        CHECK_STATUS_SUCCESS(status);
     }
 
     auto status = m_implementation->bulkGet(object_type, object_count, object_id, attr_count, attr_list, mode, object_statuses);
@@ -1416,7 +1414,7 @@ sai_status_t Meta::bulkCreate(
     {
         sai_status_t status = meta_sai_validate_oid(object_type, &object_id[idx], switchId, true);
 
-        CHECK_STATUS_SUCCESS_MODE(status, mode);
+        CHECK_STATUS_SUCCESS(status);
 
         // this is create, oid's don't exist yet
 
@@ -1426,7 +1424,7 @@ sai_status_t Meta::bulkCreate(
 
         status = meta_generic_validation_create(meta_key, switchId, attr_count[idx], attr_list[idx]);
 
-        CHECK_STATUS_SUCCESS_MODE(status, mode);
+        CHECK_STATUS_SUCCESS(status);
     }
 
     auto status = m_implementation->bulkCreate(object_type, switchId, object_count, attr_count, attr_list, mode, object_id, object_statuses);

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -206,6 +206,7 @@ struct BulkStatsContext
     std::vector<uint64_t> counters;
     std::string name;
     uint32_t default_bulk_chunk_size;
+    std::unordered_set<sai_object_id_t> object_vids_set;
 };
 
 // TODO: use if const expression when cpp17 is supported
@@ -765,6 +766,7 @@ public:
                     bulkContext.get()->counter_ids = move(counterPrefix.second);
                     bulkContext.get()->object_statuses.resize(singleBulkContext.get()->object_statuses.size());
                     bulkContext.get()->object_vids = singleBulkContext.get()->object_vids;
+                    bulkContext.get()->object_vids_set = singleBulkContext.get()->object_vids_set;
                     bulkContext.get()->object_keys = singleBulkContext.get()->object_keys;
                     bulkContext.get()->counters.resize(bulkContext.get()->counter_ids.size() * bulkContext.get()->object_vids.size());
 
@@ -1382,7 +1384,15 @@ private:
             _Inout_ BulkContextType &ctx)
     {
         SWSS_LOG_ENTER();
+        
+        if (ctx.object_vids_set.find(vid) != ctx.object_vids_set.end())
+        {
+            SWSS_LOG_INFO("VID 0x%" PRIx64 " already exists in bulk context, skipping", vid);
+            return;
+        }
+        
         ctx.object_vids.push_back(vid);
+        ctx.object_vids_set.insert(vid);
         sai_object_key_t object_key;
         object_key.key.object_id = rid;
         ctx.object_keys.push_back(object_key);
@@ -1397,13 +1407,26 @@ private:
             _Inout_ BulkContextType &ctx)
     {
         SWSS_LOG_ENTER();
-        ctx.object_vids.insert(ctx.object_vids.end(), vids.begin(), vids.end());
-        transform(rids.begin(), rids.end(), back_inserter(ctx.object_keys), [](sai_object_id_t rid) {
+        // Add objects only if they don't already exist to avoid duplicates
+        for (size_t i = 0; i < vids.size(); i++)
+        {
+            auto vid = vids[i];
+            auto rid = rids[i];
+            
+            if (ctx.object_vids_set.find(vid) != ctx.object_vids_set.end())
+            {
+                SWSS_LOG_INFO("VID 0x%" PRIx64 " already exists in bulk context, skipping", vid);
+                continue;
+            }
+            
+            // Add the object
+            ctx.object_vids.push_back(vid);
+            ctx.object_vids_set.insert(vid);
             sai_object_key_t key;
             key.key.object_id = rid;
-            return key;
-        });
-        ctx.object_statuses.insert(ctx.object_statuses.end(), vids.size(), SAI_STATUS_SUCCESS);
+            ctx.object_keys.push_back(key);
+            ctx.object_statuses.push_back(SAI_STATUS_SUCCESS);
+        }
         ctx.counters.resize(counterIds.size() * ctx.object_keys.size());
     }
 
@@ -1424,6 +1447,7 @@ private:
             found = true;
             auto index = std::distance(ctx.object_vids.begin(), vid_iter);
             ctx.object_vids.erase(vid_iter);
+            ctx.object_vids_set.erase(vid);
             if (ctx.object_vids.empty())
             {
                 // It can change the order of the map to erase an element in a loop iterating the map

--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1384,13 +1384,13 @@ private:
             _Inout_ BulkContextType &ctx)
     {
         SWSS_LOG_ENTER();
-        
+
         if (ctx.object_vids_set.find(vid) != ctx.object_vids_set.end())
         {
             SWSS_LOG_INFO("VID 0x%" PRIx64 " already exists in bulk context, skipping", vid);
             return;
         }
-        
+
         ctx.object_vids.push_back(vid);
         ctx.object_vids_set.insert(vid);
         sai_object_key_t object_key;
@@ -1412,14 +1412,13 @@ private:
         {
             auto vid = vids[i];
             auto rid = rids[i];
-            
+
             if (ctx.object_vids_set.find(vid) != ctx.object_vids_set.end())
             {
                 SWSS_LOG_INFO("VID 0x%" PRIx64 " already exists in bulk context, skipping", vid);
                 continue;
             }
-            
-            // Add the object
+
             ctx.object_vids.push_back(vid);
             ctx.object_vids_set.insert(vid);
             sai_object_key_t key;

--- a/vslib/vpp/SwitchVpp.cpp
+++ b/vslib/vpp/SwitchVpp.cpp
@@ -39,6 +39,21 @@ SwitchVpp::SwitchVpp(
     vpp_dp_initialize();
 }
 
+SwitchVpp::~SwitchVpp()
+{
+    SWSS_LOG_ENTER();
+
+    // Signal the vpp events thread to stop
+    m_run_vpp_events_thread = false;
+
+    // Wait for the thread to finish gracefully
+    if (m_vpp_thread && m_vpp_thread->joinable()) {
+        m_vpp_thread->join();
+    }
+
+    SWSS_LOG_NOTICE("SwitchVpp destructor completed");
+}
+
 sai_status_t SwitchVpp::create_qos_queues_per_port(
         _In_ sai_object_id_t port_id)
 {

--- a/vslib/vpp/SwitchVpp.h
+++ b/vslib/vpp/SwitchVpp.h
@@ -41,7 +41,7 @@ namespace saivs
                     _In_ std::shared_ptr<SwitchConfig> config,
                     _In_ std::shared_ptr<WarmBootState> warmBootState);
 
-            virtual ~SwitchVpp() = default;
+            virtual ~SwitchVpp();
 
         protected:
 

--- a/vslib/vpp/vppxlate/SaiVppXlate.c
+++ b/vslib/vpp/vppxlate/SaiVppXlate.c
@@ -1748,7 +1748,7 @@ int init_vpp_client()
 
     vpp_mutex_lock_init();
 
-    clib_mem_init_thread_safe(0, 128 << 20);
+    clib_mem_init(0, 128 << 20);
     vlib_main_init();
     clib_time_init (&vam->clib_time);
     /* Set up the plugin message ID allocator right now... */


### PR DESCRIPTION
When PFC Watchdog or other features start collecting bulk statistics, duplicate ports can be added to the bulk stats context

Root Cause:
-----------
The addBulkStatsContext() functions did not check for duplicate VIDs before adding objects to the bulk context. The object_vids vector could contain the same VID multiple times, leading to duplicate RIDs being passed to the SAI bulk stats API.

Solution:
---------
1. Added object_vids_set (unordered_set) to BulkStatsContext
2. Modified both addBulkStatsContext() overloads to check the set before adding new objects
3. Updated removeBulkStatsContext() to maintain set consistency