### PR TITLE
[syncd] Return early after saving lane map on first start

### DIFF
--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -334,6 +334,8 @@ void SaiSwitch::helperCheckLaneMap()
         m_client->saveLaneMap(m_switch_vid, laneMap);
 
         redisLaneMap = laneMap; // copy
+        SWSS_LOG_NOTICE("Saved %zu lanes to Redis, continuing normally", laneMap.size());
+        return;
     }
 
     if (laneMap.size() != redisLaneMap.size())


### PR DESCRIPTION
Add return statement after initializing Redis lane map to prevent subsequent validation checks from running against freshly initialized data. This avoids false positive errors during first syncd start.