### PR TITLE
Fix deadlock between syncd and orchagent syncd initialization failure

### DIFF
--- a/.azure-pipelines/build-swss-template.yml
+++ b/.azure-pipelines/build-swss-template.yml
@@ -18,9 +18,6 @@ parameters:
   type: number
   default: 60
 
-- name: sonic_slave
-  type: string
-
 - name: debian_version
   type: string
 
@@ -48,7 +45,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
 
   container:
-    image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-${{ parameters.debian_version }}:$(BUILD_BRANCH)-${{ parameters.arch }}
 
   steps:
   - checkout: sonic-swss

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -62,7 +62,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
 
   container:
-    image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:latest
+    image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:$(BUILD_BRANCH)
     options:  "--privileged"
 
   steps:

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -19,9 +19,6 @@ parameters:
   type: number
   default: 60
 
-- name: sonic_slave
-  type: string
-
 - name: swss_common_artifact_name
   type: string
 
@@ -62,7 +59,7 @@ jobs:
       vmImage: 'ubuntu-22.04'
 
   container:
-    image: sonicdev-microsoft.azurecr.io:443/${{ parameters.sonic_slave }}:$(BUILD_BRANCH)
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-${{ parameters.debian_version }}:$(BUILD_BRANCH)-${{ parameters.arch }}
     options:  "--privileged"
 
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,6 @@ stages:
     parameters:
       arch: amd64
       pool: sonicso1ES-amd64
-      sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       artifact_name: sonic-sairedis-${{ parameters.debian_version }}
       syslog_artifact_name: sonic-sairedis.syslog
@@ -68,7 +67,6 @@ stages:
     parameters:
       arch: amd64
       pool: sonicso1ES-amd64
-      sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       artifact_name: sonic-sairedis-asan-${{ parameters.debian_version }}
       syslog_artifact_name: sonic-sairedis-asan.syslog
@@ -86,7 +84,6 @@ stages:
       arch: armhf
       timeout: 180
       pool: sonicso1ES-armhf
-      sonic_slave: sonic-slave-${{ parameters.debian_version }}-armhf
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}.armhf
       artifact_name: sonic-sairedis-${{ parameters.debian_version }}.armhf
       syslog_artifact_name: sonic-sairedis.syslog.armhf
@@ -97,7 +94,6 @@ stages:
       arch: arm64
       timeout: 180
       pool: sonicso1ES-arm64
-      sonic_slave: sonic-slave-${{ parameters.debian_version }}-arm64
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}.arm64
       artifact_name: sonic-sairedis-${{ parameters.debian_version }}.arm64
       syslog_artifact_name: sonic-sairedis.syslog.arm64
@@ -112,7 +108,6 @@ stages:
       arch: amd64
       timeout: 90
       pool: sonicso1ES-amd64
-      sonic_slave: sonic-slave-${{ parameters.debian_version }}
       swss_common_artifact_name: sonic-swss-common-${{ parameters.debian_version }}
       sairedis_artifact_name: sonic-sairedis-${{ parameters.debian_version }}
       syslog_artifact_name: sonic-swss.syslog

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -5899,8 +5899,11 @@ void Syncd::run()
             {
                 if (inShutdownWaitMode)
                 {
-                    // We're waiting for shutdown but received a command
-                    // Need to respond to avoid deadlock with orchagent
+                // Syncd in shutdown-wait mode must respond to INIT_VIEW with FAILURE to avoid deadlock with OA
+                // This could happen because Orchagent sends INIT_VIEW before registering shutdown callback
+                // Can't reorder due to circular dependency: need switch to register callbacks, but
+                //      need INIT_VIEW before creating switch
+
                     swss::KeyOpFieldsValuesTuple kco;
                     m_selectableChannel->pop(kco, false);
                     

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -5736,6 +5736,8 @@ void Syncd::run()
     syncd_restart_type_t shutdownType = SYNCD_RESTART_TYPE_COLD;
 
     volatile bool runMainLoop = true;
+    
+    bool inShutdownWaitMode = false;
 
     std::shared_ptr<swss::Select> s = std::make_shared<swss::Select>();
 
@@ -5774,6 +5776,9 @@ void Syncd::run()
         s = std::make_shared<swss::Select>();
 
         s->addSelectable(m_restartQuery.get());
+        s->addSelectable(m_selectableChannel.get());
+        
+        inShutdownWaitMode = true;
 
         SWSS_LOG_NOTICE("starting main loop, ONLY restart query");
 
@@ -5892,7 +5897,32 @@ void Syncd::run()
             }
             else if (sel == m_selectableChannel.get())
             {
-                processEvent(*m_selectableChannel.get());
+                if (inShutdownWaitMode)
+                {
+                    // We're waiting for shutdown but received a command
+                    // Need to respond to avoid deadlock with orchagent
+                    swss::KeyOpFieldsValuesTuple kco;
+                    m_selectableChannel->pop(kco, false);
+                    
+                    auto& op = kfvOp(kco);
+                    auto& key = kfvKey(kco);
+                    
+                    SWSS_LOG_WARN("Received command while in shutdown-wait mode Command: op=%s, key=%s", op.c_str(), key.c_str());
+                    
+                    if (op == REDIS_ASIC_STATE_COMMAND_NOTIFY)
+                    {
+                        SWSS_LOG_ERROR("Syncd is waiting for shutdown, cannot process %s Sending FAILURE response", key.c_str());
+                        sendNotifyResponse(SAI_STATUS_FAILURE);
+                    }
+                    else
+                    {
+                        SWSS_LOG_WARN("Ignoring non-notify command in shutdown-wait mode");
+                    }
+                }
+                else
+                {
+                    processEvent(*m_selectableChannel.get());
+                }
             }
             else
             {
@@ -5901,13 +5931,16 @@ void Syncd::run()
         }
         catch(const std::exception &e)
         {
-            SWSS_LOG_ERROR("Runtime error: %s", e.what());
+            SWSS_LOG_ERROR("Runtime error: %s - entering shutdown-wait mode", e.what());
 
             sendShutdownRequestAfterException();
 
             s = std::make_shared<swss::Select>();
 
             s->addSelectable(m_restartQuery.get());
+            s->addSelectable(m_selectableChannel.get());
+            
+            inShutdownWaitMode = true;
 
             if (m_commandLineOptions->m_disableExitSleep)
                 runMainLoop = false;

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -5736,7 +5736,7 @@ void Syncd::run()
     syncd_restart_type_t shutdownType = SYNCD_RESTART_TYPE_COLD;
 
     volatile bool runMainLoop = true;
-    
+
     bool inShutdownWaitMode = false;
 
     std::shared_ptr<swss::Select> s = std::make_shared<swss::Select>();
@@ -5777,7 +5777,7 @@ void Syncd::run()
 
         s->addSelectable(m_restartQuery.get());
         s->addSelectable(m_selectableChannel.get());
-        
+
         inShutdownWaitMode = true;
 
         SWSS_LOG_NOTICE("starting main loop, ONLY restart query");
@@ -5906,12 +5906,12 @@ void Syncd::run()
 
                     swss::KeyOpFieldsValuesTuple kco;
                     m_selectableChannel->pop(kco, false);
-                    
+
                     auto& op = kfvOp(kco);
                     auto& key = kfvKey(kco);
-                    
+
                     SWSS_LOG_WARN("Received command while in shutdown-wait mode Command: op=%s, key=%s", op.c_str(), key.c_str());
-                    
+
                     if (op == REDIS_ASIC_STATE_COMMAND_NOTIFY)
                     {
                         SWSS_LOG_ERROR("Syncd is waiting for shutdown, cannot process %s Sending FAILURE response", key.c_str());
@@ -5942,7 +5942,7 @@ void Syncd::run()
 
             s->addSelectable(m_restartQuery.get());
             s->addSelectable(m_selectableChannel.get());
-            
+
             inShutdownWaitMode = true;
 
             if (m_commandLineOptions->m_disableExitSleep)

--- a/syncd/Syncd.h
+++ b/syncd/Syncd.h
@@ -67,6 +67,9 @@ namespace syncd
             void processEvent(
                     _In_ sairedis::SelectableChannel& consumer);
 
+            void processEventInShutdownWaitMode(
+                    _In_ sairedis::SelectableChannel& consumer);
+
             sai_status_t processQuadEventInInitViewMode(
                     _In_ sai_object_type_t objectType,
                     _In_ const std::string& strObjectId,

--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -394,6 +394,10 @@ config_syncd_mlnx()
 
     # Ensure no redundant newlines
     sed -i '/^$/d' /tmp/sai.profile
+
+    # As long as sonic does not support PTP which can be enabled/disabled, Nvidia platforms enables
+    # phcsync for all systems. If HW does not support it, it will do nothing.
+    supervisorctl start phcsync
 }
 
 config_syncd_centec()


### PR DESCRIPTION
When syncd requests a shutdown, orchagent may be blocked waiting for a response to an init view (or other NOTIFY) command. Since syncd stops processing commands while waiting for the shutdown response, orchagent never receives its response and cannot acknowledge the shutdown request - resulting in a deadlock.

This fix adds the selectable channel to the select loop during shutdown-wait mode and handles incoming commands appropriately:
- NOTIFY commands receive a SAI_STATUS_FAILURE response to unblock the waiting orchagent
- Other commands are logged and ignored

This prevents orchagent from hanging until timout when syncd is failing.